### PR TITLE
Using ADASYN for Oversampling

### DIFF
--- a/credit-card-fraud-detection-using-neural-networks.ipynb
+++ b/credit-card-fraud-detection-using-neural-networks.ipynb
@@ -2417,7 +2417,7 @@
     "ada = ADASYN(sampling_strategy='minority', random_state=42)\n",
     "\n",
     "#Oversampling is applied only on the training set\n",
-    "X_adasampled, Y_adasampled = ada.fit_sample(Xtrain_final, Ytrain_final)\n",
+    "X_adasampled, Y_adasampled = ada.fit_resample(Xtrain_final, Ytrain_final)\n",
     "print('Resampled dataset shape %s' % Counter(Y_adasampled))\n",
     "print('Shape of X_adasampled: {}'.format(X_adasampled.shape))\n",
     "print('Shape of Y_adasampled: {}'.format(Y_adasampled.shape))"


### PR DESCRIPTION
Oversampling is applied only on the training set
"X_adasampled, Y_adasampled = ada.fit_resample(Xtrain_final, Ytrain_final)\n",

fit_resample(X, y) | Resample the dataset.
   Parameters:

        X{array-like, dataframe, sparse matrix} of shape (n_samples, n_features)

            Matrix containing the data which have to be sampled.
        yarray-like of shape (n_samples,)

            Corresponding label for each sample in X.

    Returns:

        X_resampled{array-like, dataframe, sparse matrix} of shape (n_samples_new, n_features)

            The array containing the resampled data.
        y_resampledarray-like of shape (n_samples_new,)

            The corresponding label of X_resampled.


_No module named sample_